### PR TITLE
Add macao on country list

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -12,6 +12,7 @@ chinese_encode = "ISO-8859-1"
 nocn_country_map = {
     "香港": "Hong Kong",
     "台湾": "Taiwan",
+    "澳门": "Macao",
 }
 
 country_map = {


### PR DESCRIPTION
I added "Macao Special Administrative Region of the People's Republic of China" on nocn_country_map.